### PR TITLE
Improve metadata: fix Bundesliga audit findings across all leagues

### DIFF
--- a/datasets/bundesliga/README.md
+++ b/datasets/bundesliga/README.md
@@ -1,1 +1,11 @@
-This dataset contains data for last 10 seasons of German Bundesliga including current season. The data is updated on weekly basis via Travis-CI. The dataset is sourced from http://www.football-data.co.uk/ website and contains various statistical data such as final and half time result, corners, yellow and red cards etc.
+This dataset contains match results for every German Bundesliga season from 1993/94 to present (33 seasons). It includes full-time and half-time scores, referee, shots, corners, fouls, and yellow/red cards. The data is updated daily via GitHub Actions. The dataset is sourced from https://www.football-data.co.uk/.
+
+## Data notes
+
+- **Date format**: Seasons from 2018/19 onwards use ISO 8601 dates (YYYY-MM-DD). Earlier seasons retain the source format (dd/mm/yy).
+- **Missing statistics**: Referee, shots, shots on target, fouls, corners, and card fields are blank for many early seasons (1993/94–2001/02) because the source did not record those statistics at the time.
+- **Partial statistics**: Some mid-2000s seasons have shots and corners but lack shots-on-target data.
+
+## License
+
+[Open Data Commons Public Domain Dedication and License (ODC-PDDL-1.0)](https://opendatacommons.org/licenses/pddl/)

--- a/datasets/bundesliga/datapackage.json
+++ b/datasets/bundesliga/datapackage.json
@@ -1,6 +1,7 @@
 {
   "name": "german-bundesliga",
   "title": "German Bundesliga (football)",
+  "description": "Match results for every German Bundesliga season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk.",
   "resources": [
     {
       "name": "season-9900",
@@ -12,13 +13,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1999/00 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -67,6 +69,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -156,13 +164,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1998/99 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -211,6 +220,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -300,13 +315,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1997/98 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -355,6 +371,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -444,13 +466,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1996/97 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -499,6 +522,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -588,13 +617,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1995/96 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -643,6 +673,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -732,13 +768,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1994/95 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -787,6 +824,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -876,13 +919,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 1993/94 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -931,6 +975,163 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
+          },
+          {
+            "name": "HS",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Shots"
+          },
+          {
+            "name": "AS",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Shots"
+          },
+          {
+            "name": "HST",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Shots on Target"
+          },
+          {
+            "name": "AST",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Shots on Target"
+          },
+          {
+            "name": "HF",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Fouls Committed"
+          },
+          {
+            "name": "AF",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Fouls Committed"
+          },
+          {
+            "name": "HC",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Corners"
+          },
+          {
+            "name": "AC",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Corners"
+          },
+          {
+            "name": "HY",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Yellow Cards"
+          },
+          {
+            "name": "AY",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Yellow Cards"
+          },
+          {
+            "name": "HR",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Red Cards"
+          },
+          {
+            "name": "AR",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Red Cards"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "name": "season-2526",
+      "path": "season-2526.csv",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "ISO-8859-1",
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "description": "German Bundesliga season 2025/26 match results.",
+      "schema": {
+        "fields": [
+          {
+            "name": "Date",
+            "type": "date",
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+          },
+          {
+            "name": "HomeTeam",
+            "type": "string",
+            "format": "default",
+            "description": "Home Team"
+          },
+          {
+            "name": "AwayTeam",
+            "type": "string",
+            "format": "default",
+            "description": "Away Team"
+          },
+          {
+            "name": "FTHG",
+            "type": "integer",
+            "format": "default",
+            "description": "Full Time Home Team Goals"
+          },
+          {
+            "name": "FTAG",
+            "type": "integer",
+            "format": "default",
+            "description": "Full Time Away Team Goals"
+          },
+          {
+            "name": "FTR",
+            "type": "string",
+            "format": "default",
+            "description": "Full Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "HTHG",
+            "type": "integer",
+            "format": "default",
+            "description": "Half Time Home Team Goals"
+          },
+          {
+            "name": "HTAG",
+            "type": "integer",
+            "format": "default",
+            "description": "Half Time Away Team Goals"
+          },
+          {
+            "name": "HTR",
+            "type": "string",
+            "format": "default",
+            "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1020,13 +1221,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2024/25 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1075,6 +1277,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1164,13 +1372,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2023/24 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1219,6 +1428,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1308,13 +1523,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2022/23 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1363,6 +1579,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1452,13 +1674,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2021/22 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1507,6 +1730,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1596,13 +1825,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2020/21 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1651,6 +1881,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1740,13 +1976,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2019/20 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1795,6 +2032,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1884,13 +2127,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2018/19 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1939,6 +2183,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2028,13 +2278,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2017/18 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2083,6 +2334,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2172,13 +2429,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2016/17 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2227,6 +2485,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2316,13 +2580,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2015/16 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2371,6 +2636,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2460,13 +2731,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2014/15 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2515,6 +2787,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2604,13 +2882,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2013/14 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2659,6 +2938,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2748,13 +3033,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2012/13 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2803,6 +3089,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2892,13 +3184,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2011/12 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2947,6 +3240,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3036,13 +3335,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2010/11 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3091,6 +3391,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3180,13 +3486,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2009/10 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3235,6 +3542,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3324,13 +3637,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2008/09 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3379,6 +3693,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3468,13 +3788,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2007/08 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3523,6 +3844,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3612,13 +3939,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2006/07 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3667,6 +3995,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3756,13 +4090,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2005/06 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3811,6 +4146,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3900,13 +4241,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2004/05 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3955,6 +4297,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4044,13 +4392,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2003/04 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4099,6 +4448,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4188,13 +4543,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2002/03 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4243,6 +4599,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4332,13 +4694,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2001/02 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4387,6 +4750,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4476,13 +4845,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "German Bundesliga season 2000/01 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4531,6 +4901,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4613,16 +4989,16 @@
   ],
   "licenses": [
     {
-      "name": "ODC-PDDL",
-      "path": "http://opendatacommons.org/licenses/pddl/",
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/",
       "title": "Open Data Commons Public Domain Dedication and License"
     }
   ],
   "sources": [
     {
-      "name": "www.football-data.co.uk/",
-      "path": "http://www.football-data.co.uk/",
-      "title": "www.football-data.co.uk/"
+      "name": "Football-Data.co.uk",
+      "path": "https://www.football-data.co.uk/",
+      "title": "Football-Data.co.uk"
     }
   ],
   "related": [

--- a/datasets/bundesliga/schema.json
+++ b/datasets/bundesliga/schema.json
@@ -3,8 +3,8 @@
     {
       "name": "Date",
       "type": "date",
-      "format": "%d/%m/%y",
-      "description": "Match Date (dd/mm/yy)"
+      "format": "default",
+      "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
     },
     {
       "name": "HomeTeam",
@@ -53,6 +53,12 @@
       "type": "string",
       "format": "default",
       "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+    },
+    {
+      "name": "Referee",
+      "type": "string",
+      "format": "default",
+      "description": "Match Referee"
     },
     {
       "name": "HS",

--- a/datasets/la-liga/datapackage.json
+++ b/datasets/la-liga/datapackage.json
@@ -1,6 +1,7 @@
 {
   "name": "spanish-la-liga",
   "title": "Spanish La Liga (football)",
+  "description": "Match results for every Spanish La Liga season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk.",
   "resources": [
     {
       "name": "season-9900",
@@ -12,13 +13,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1999/00 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -67,6 +69,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -156,13 +164,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1998/99 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -211,6 +220,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -300,13 +315,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1997/98 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -355,6 +371,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -444,13 +466,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1996/97 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -499,6 +522,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -588,13 +617,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1995/96 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -643,6 +673,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -732,13 +768,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1994/95 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -787,6 +824,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -876,13 +919,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 1993/94 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -931,6 +975,163 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
+          },
+          {
+            "name": "HS",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Shots"
+          },
+          {
+            "name": "AS",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Shots"
+          },
+          {
+            "name": "HST",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Shots on Target"
+          },
+          {
+            "name": "AST",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Shots on Target"
+          },
+          {
+            "name": "HF",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Fouls Committed"
+          },
+          {
+            "name": "AF",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Fouls Committed"
+          },
+          {
+            "name": "HC",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Corners"
+          },
+          {
+            "name": "AC",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Corners"
+          },
+          {
+            "name": "HY",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Yellow Cards"
+          },
+          {
+            "name": "AY",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Yellow Cards"
+          },
+          {
+            "name": "HR",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Red Cards"
+          },
+          {
+            "name": "AR",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Red Cards"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "name": "season-2526",
+      "path": "season-2526.csv",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "ISO-8859-1",
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "description": "Spanish La Liga season 2025/26 match results.",
+      "schema": {
+        "fields": [
+          {
+            "name": "Date",
+            "type": "date",
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+          },
+          {
+            "name": "HomeTeam",
+            "type": "string",
+            "format": "default",
+            "description": "Home Team"
+          },
+          {
+            "name": "AwayTeam",
+            "type": "string",
+            "format": "default",
+            "description": "Away Team"
+          },
+          {
+            "name": "FTHG",
+            "type": "integer",
+            "format": "default",
+            "description": "Full Time Home Team Goals"
+          },
+          {
+            "name": "FTAG",
+            "type": "integer",
+            "format": "default",
+            "description": "Full Time Away Team Goals"
+          },
+          {
+            "name": "FTR",
+            "type": "string",
+            "format": "default",
+            "description": "Full Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "HTHG",
+            "type": "integer",
+            "format": "default",
+            "description": "Half Time Home Team Goals"
+          },
+          {
+            "name": "HTAG",
+            "type": "integer",
+            "format": "default",
+            "description": "Half Time Away Team Goals"
+          },
+          {
+            "name": "HTR",
+            "type": "string",
+            "format": "default",
+            "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1020,13 +1221,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2024/25 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1075,6 +1277,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1164,13 +1372,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2023/24 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1219,6 +1428,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1308,13 +1523,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2022/23 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1363,6 +1579,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1452,13 +1674,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2021/22 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1507,6 +1730,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1596,13 +1825,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2020/21 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1651,6 +1881,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1740,13 +1976,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2019/20 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1795,6 +2032,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1884,13 +2127,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2018/19 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1939,6 +2183,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2028,13 +2278,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2017/18 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2083,6 +2334,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2172,13 +2429,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2016/17 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2227,6 +2485,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2316,13 +2580,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2015/16 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2371,6 +2636,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2460,13 +2731,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2014/15 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2515,6 +2787,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2604,13 +2882,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2013/14 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2659,6 +2938,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2748,13 +3033,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2012/13 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2803,6 +3089,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2892,13 +3184,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2011/12 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2947,6 +3240,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3036,13 +3335,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2010/11 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3091,6 +3391,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3180,13 +3486,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2009/10 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3235,6 +3542,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3324,13 +3637,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2008/09 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3379,6 +3693,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3468,13 +3788,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2007/08 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3523,6 +3844,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3612,13 +3939,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2006/07 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3667,6 +3995,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3756,13 +4090,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2005/06 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3811,6 +4146,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3900,13 +4241,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2004/05 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3955,6 +4297,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4044,13 +4392,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2003/04 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4099,6 +4448,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4188,13 +4543,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2002/03 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4243,6 +4599,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4332,13 +4694,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2001/02 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4387,6 +4750,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4476,13 +4845,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "Spanish La Liga season 2000/01 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4531,6 +4901,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4613,16 +4989,16 @@
   ],
   "licenses": [
     {
-      "name": "ODC-PDDL",
-      "path": "http://opendatacommons.org/licenses/pddl/",
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/",
       "title": "Open Data Commons Public Domain Dedication and License"
     }
   ],
   "sources": [
     {
-      "name": "www.football-data.co.uk/",
-      "path": "http://www.football-data.co.uk/",
-      "title": "www.football-data.co.uk/"
+      "name": "Football-Data.co.uk",
+      "path": "https://www.football-data.co.uk/",
+      "title": "Football-Data.co.uk"
     }
   ],
   "related": [

--- a/datasets/la-liga/schema.json
+++ b/datasets/la-liga/schema.json
@@ -3,8 +3,8 @@
     {
       "name": "Date",
       "type": "date",
-      "format": "%d/%m/%y",
-      "description": "Match Date (dd/mm/yy)"
+      "format": "default",
+      "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
     },
     {
       "name": "HomeTeam",
@@ -53,6 +53,12 @@
       "type": "string",
       "format": "default",
       "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+    },
+    {
+      "name": "Referee",
+      "type": "string",
+      "format": "default",
+      "description": "Match Referee"
     },
     {
       "name": "HS",

--- a/datasets/ligue-1/datapackage.json
+++ b/datasets/ligue-1/datapackage.json
@@ -1,6 +1,7 @@
 {
   "name": "french-ligue-1",
   "title": "French Ligue 1 (football)",
+  "description": "Match results for every French Ligue 1 season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk.",
   "resources": [
     {
       "name": "season-9900",
@@ -12,13 +13,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1999/00 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -67,6 +69,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -156,13 +164,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1998/99 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -211,6 +220,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -300,13 +315,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1997/98 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -355,6 +371,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -444,13 +466,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1996/97 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -499,6 +522,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -588,13 +617,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1995/96 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -643,6 +673,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -732,13 +768,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1994/95 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -787,6 +824,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -876,13 +919,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 1993/94 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -931,6 +975,163 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
+          },
+          {
+            "name": "HS",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Shots"
+          },
+          {
+            "name": "AS",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Shots"
+          },
+          {
+            "name": "HST",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Shots on Target"
+          },
+          {
+            "name": "AST",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Shots on Target"
+          },
+          {
+            "name": "HF",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Fouls Committed"
+          },
+          {
+            "name": "AF",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Fouls Committed"
+          },
+          {
+            "name": "HC",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Corners"
+          },
+          {
+            "name": "AC",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Corners"
+          },
+          {
+            "name": "HY",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Yellow Cards"
+          },
+          {
+            "name": "AY",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Yellow Cards"
+          },
+          {
+            "name": "HR",
+            "type": "integer",
+            "format": "default",
+            "description": "Home Team Red Cards"
+          },
+          {
+            "name": "AR",
+            "type": "integer",
+            "format": "default",
+            "description": "Away Team Red Cards"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    },
+    {
+      "name": "season-2526",
+      "path": "season-2526.csv",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "ISO-8859-1",
+      "dialect": {
+        "delimiter": ",",
+        "quoteChar": "\""
+      },
+      "description": "French Ligue 1 season 2025/26 match results.",
+      "schema": {
+        "fields": [
+          {
+            "name": "Date",
+            "type": "date",
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+          },
+          {
+            "name": "HomeTeam",
+            "type": "string",
+            "format": "default",
+            "description": "Home Team"
+          },
+          {
+            "name": "AwayTeam",
+            "type": "string",
+            "format": "default",
+            "description": "Away Team"
+          },
+          {
+            "name": "FTHG",
+            "type": "integer",
+            "format": "default",
+            "description": "Full Time Home Team Goals"
+          },
+          {
+            "name": "FTAG",
+            "type": "integer",
+            "format": "default",
+            "description": "Full Time Away Team Goals"
+          },
+          {
+            "name": "FTR",
+            "type": "string",
+            "format": "default",
+            "description": "Full Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "HTHG",
+            "type": "integer",
+            "format": "default",
+            "description": "Half Time Home Team Goals"
+          },
+          {
+            "name": "HTAG",
+            "type": "integer",
+            "format": "default",
+            "description": "Half Time Away Team Goals"
+          },
+          {
+            "name": "HTR",
+            "type": "string",
+            "format": "default",
+            "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1020,13 +1221,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2024/25 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1075,6 +1277,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1164,13 +1372,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2023/24 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1219,6 +1428,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1308,13 +1523,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2022/23 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1363,6 +1579,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1452,13 +1674,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2021/22 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1507,6 +1730,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1596,13 +1825,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2020/21 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1651,6 +1881,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1740,13 +1976,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2019/20 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1795,6 +2032,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -1884,13 +2127,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2018/19 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -1939,6 +2183,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2028,13 +2278,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2017/18 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2083,6 +2334,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2172,13 +2429,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2016/17 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2227,6 +2485,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2316,13 +2580,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2015/16 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2371,6 +2636,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2460,13 +2731,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2014/15 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2515,6 +2787,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2604,13 +2882,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2013/14 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2659,6 +2938,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2748,13 +3033,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2012/13 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2803,6 +3089,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -2892,13 +3184,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2011/12 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -2947,6 +3240,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3036,13 +3335,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2010/11 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3091,6 +3391,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3180,13 +3486,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2009/10 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3235,6 +3542,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3324,13 +3637,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2008/09 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3379,6 +3693,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3468,13 +3788,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2007/08 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3523,6 +3844,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3612,13 +3939,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2006/07 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3667,6 +3995,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3756,13 +4090,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2005/06 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3811,6 +4146,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -3900,13 +4241,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2004/05 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -3955,6 +4297,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4044,13 +4392,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2003/04 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4099,6 +4448,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4188,13 +4543,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2002/03 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4243,6 +4599,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4332,13 +4694,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2001/02 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4387,6 +4750,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4476,13 +4845,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
+      "description": "French Ligue 1 season 2000/01 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "%d/%m/%y",
-            "description": "Match Date (dd/mm/yy)"
+            "format": "default",
+            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
           },
           {
             "name": "HomeTeam",
@@ -4531,6 +4901,12 @@
             "type": "string",
             "format": "default",
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+          },
+          {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee"
           },
           {
             "name": "HS",
@@ -4613,16 +4989,16 @@
   ],
   "licenses": [
     {
-      "name": "ODC-PDDL",
-      "path": "http://opendatacommons.org/licenses/pddl/",
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/",
       "title": "Open Data Commons Public Domain Dedication and License"
     }
   ],
   "sources": [
     {
-      "name": "www.football-data.co.uk/",
-      "path": "http://www.football-data.co.uk/",
-      "title": "www.football-data.co.uk/"
+      "name": "Football-Data.co.uk",
+      "path": "https://www.football-data.co.uk/",
+      "title": "Football-Data.co.uk"
     }
   ],
   "related": [

--- a/datasets/ligue-1/schema.json
+++ b/datasets/ligue-1/schema.json
@@ -3,8 +3,8 @@
     {
       "name": "Date",
       "type": "date",
-      "format": "%d/%m/%y",
-      "description": "Match Date (dd/mm/yy)"
+      "format": "default",
+      "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
     },
     {
       "name": "HomeTeam",
@@ -53,6 +53,12 @@
       "type": "string",
       "format": "default",
       "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+    },
+    {
+      "name": "Referee",
+      "type": "string",
+      "format": "default",
+      "description": "Match Referee"
     },
     {
       "name": "HS",

--- a/datasets/premier-league/datapackage.json
+++ b/datasets/premier-league/datapackage.json
@@ -1,7 +1,7 @@
 {
-  "name": "italian-serie-a",
-  "title": "Italian Serie A (football)",
-  "description": "Match results for every Italian Serie A season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk.",
+  "name": "english-premier-league",
+  "title": "English Premier League (football)",
+  "description": "Match results for every English Premier League season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk.",
   "resources": [
     {
       "name": "season-9900",
@@ -13,14 +13,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1999/00 match results.",
+      "description": "English Premier League season 1999/00 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -164,14 +164,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1998/99 match results.",
+      "description": "English Premier League season 1998/99 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -315,14 +315,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1997/98 match results.",
+      "description": "English Premier League season 1997/98 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -466,14 +466,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1996/97 match results.",
+      "description": "English Premier League season 1996/97 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -617,14 +617,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1995/96 match results.",
+      "description": "English Premier League season 1995/96 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -768,14 +768,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1994/95 match results.",
+      "description": "English Premier League season 1994/95 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -919,14 +919,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 1993/94 match results.",
+      "description": "English Premier League season 1993/94 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1070,14 +1070,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2025/26 match results.",
+      "description": "English Premier League season 2025/26 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1221,14 +1221,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2024/25 match results.",
+      "description": "English Premier League season 2024/25 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1372,14 +1372,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2023/24 match results.",
+      "description": "English Premier League season 2023/24 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1523,14 +1523,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2022/23 match results.",
+      "description": "English Premier League season 2022/23 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1674,14 +1674,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2021/22 match results.",
+      "description": "English Premier League season 2021/22 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1825,14 +1825,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2020/21 match results.",
+      "description": "English Premier League season 2020/21 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -1976,14 +1976,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2019/20 match results.",
+      "description": "English Premier League season 2019/20 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -2127,14 +2127,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2018/19 match results.",
+      "description": "English Premier League season 2018/19 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -2278,14 +2278,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2017/18 match results.",
+      "description": "English Premier League season 2017/18 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -2429,14 +2429,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2016/17 match results.",
+      "description": "English Premier League season 2016/17 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -2580,14 +2580,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2015/16 match results.",
+      "description": "English Premier League season 2015/16 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -2731,14 +2731,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2014/15 match results.",
+      "description": "English Premier League season 2014/15 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -2882,14 +2882,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2013/14 match results.",
+      "description": "English Premier League season 2013/14 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3033,14 +3033,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2012/13 match results.",
+      "description": "English Premier League season 2012/13 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3184,14 +3184,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2011/12 match results.",
+      "description": "English Premier League season 2011/12 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3335,14 +3335,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2010/11 match results.",
+      "description": "English Premier League season 2010/11 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3486,14 +3486,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2009/10 match results.",
+      "description": "English Premier League season 2009/10 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3637,14 +3637,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2008/09 match results.",
+      "description": "English Premier League season 2008/09 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3788,14 +3788,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2007/08 match results.",
+      "description": "English Premier League season 2007/08 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -3939,14 +3939,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2006/07 match results.",
+      "description": "English Premier League season 2006/07 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -4090,14 +4090,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2005/06 match results.",
+      "description": "English Premier League season 2005/06 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -4241,14 +4241,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2004/05 match results.",
+      "description": "English Premier League season 2004/05 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -4392,14 +4392,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2003/04 match results.",
+      "description": "English Premier League season 2003/04 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -4543,14 +4543,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2002/03 match results.",
+      "description": "English Premier League season 2002/03 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -4694,14 +4694,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2001/02 match results.",
+      "description": "English Premier League season 2001/02 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -4845,14 +4845,14 @@
         "delimiter": ",",
         "quoteChar": "\""
       },
-      "description": "Italian Serie A season 2000/01 match results.",
+      "description": "English Premier League season 2000/01 match results.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
             "format": "default",
-            "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
+            "description": "Match Date (YYYY-MM-DD)"
           },
           {
             "name": "HomeTeam",
@@ -5003,15 +5003,6 @@
   ],
   "related": [
     {
-      "title": "English Premier League",
-      "path": "/sports-data/english-premier-league",
-      "publisher": "sports-data",
-      "formats": [
-        "CSV",
-        "JSON"
-      ]
-    },
-    {
       "title": "Spanish La Liga",
       "path": "/sports-data/spanish-la-liga",
       "publisher": "sports-data",
@@ -5023,6 +5014,15 @@
     {
       "title": "German Bundesliga",
       "path": "/sports-data/german-bundesliga",
+      "publisher": "sports-data",
+      "formats": [
+        "CSV",
+        "JSON"
+      ]
+    },
+    {
+      "title": "Italian Serie A",
+      "path": "/sports-data/italian-serie-a",
       "publisher": "sports-data",
       "formats": [
         "CSV",

--- a/datasets/serie-a/schema.json
+++ b/datasets/serie-a/schema.json
@@ -3,8 +3,8 @@
     {
       "name": "Date",
       "type": "date",
-      "format": "%d/%m/%y",
-      "description": "Match Date (dd/mm/yy)"
+      "format": "default",
+      "description": "Match date (YYYY-MM-DD). Seasons prior to 2018/19 retain the source format dd/mm/yy."
     },
     {
       "name": "HomeTeam",
@@ -53,6 +53,12 @@
       "type": "string",
       "format": "default",
       "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
+    },
+    {
+      "name": "Referee",
+      "type": "string",
+      "format": "default",
+      "description": "Match Referee"
     },
     {
       "name": "HS",

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -4,19 +4,20 @@ import glob, json, copy
 dpjson_template = {
     "name": "",
     "title": "",
+    "description": "",
     "resources": [],
     "licenses": [
         {
-            "name": "ODC-PDDL",
-            "path": "http://opendatacommons.org/licenses/pddl/",
+            "name": "ODC-PDDL-1.0",
+            "path": "https://opendatacommons.org/licenses/pddl/",
             "title": "Open Data Commons Public Domain Dedication and License"
         }
     ],
     "sources": [
         {
-            "name": "www.football-data.co.uk/",
-            "path": "http://www.football-data.co.uk/",
-            "title": "www.football-data.co.uk/"
+            "name": "Football-Data.co.uk",
+            "path": "https://www.football-data.co.uk/",
+            "title": "Football-Data.co.uk"
         }
     ],
     "related": []
@@ -70,25 +71,39 @@ related_datasets = [
 leagues = {
     "premier-league": {
         "name": "english-premier-league",
-        "title": "English Premier League (football)"
+        "title": "English Premier League (football)",
+        "description": "Match results for every English Premier League season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk."
     },
     "la-liga": {
         "name": "spanish-la-liga",
-        "title": "Spanish La Liga (football)"
+        "title": "Spanish La Liga (football)",
+        "description": "Match results for every Spanish La Liga season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk."
     },
     "bundesliga": {
         "name": "german-bundesliga",
-        "title": "German Bundesliga (football)"
+        "title": "German Bundesliga (football)",
+        "description": "Match results for every German Bundesliga season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk."
     },
     "serie-a": {
         "name": "italian-serie-a",
-        "title": "Italian Serie A (football)"
+        "title": "Italian Serie A (football)",
+        "description": "Match results for every Italian Serie A season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk."
     },
     "ligue-1": {
         "name": "french-ligue-1",
-        "title": "French Ligue 1 (football)"
+        "title": "French Ligue 1 (football)",
+        "description": "Match results for every French Ligue 1 season from 1993/94 to present, including full-time and half-time scores, referee, shots, corners, fouls, and cards. Updated daily. Source: Football-Data.co.uk."
     }
 }
+
+
+def season_label(resource_name):
+    """Convert a season resource name like 'season-9394' to a human label like '1993/94'."""
+    code = resource_name.replace("season-", "")
+    s, e = int(code[:2]), code[2:]
+    start = (1900 + s) if s >= 60 else (2000 + s)
+    return f"{start}/{e}"
+
 
 league_dirs = glob.glob('datasets/*')
 
@@ -97,6 +112,7 @@ for league_dir in league_dirs:
     league_name = league_dir.split('/')[1]
     dpjson['name'] = leagues[league_name]['name']
     dpjson['title'] = leagues[league_name]['title']
+    dpjson['description'] = leagues[league_name]['description']
     with open(league_dir + '/schema.json') as schema:
         schema = json.load(schema)
         resources = sorted(glob.glob(league_dir + '/*.csv'), reverse=True)
@@ -105,6 +121,8 @@ for league_dir in league_dirs:
             descriptor = copy.deepcopy(resource_descriptor)
             descriptor['path'] = resource
             descriptor['name'] = resource.replace('.csv', '')
+            label = season_label(descriptor['name'])
+            descriptor['description'] = f"{leagues[league_name]['title'].split(' (')[0]} season {label} match results."
             descriptor['schema'] = copy.deepcopy(schema)
             dpjson['resources'].append(descriptor)
         # Add related datasets:


### PR DESCRIPTION
## Summary

- Add package-level `description` to all five leagues in `package.py`
- Fix `licenses[0].name` from `ODC-PDDL` to `ODC-PDDL-1.0`; fix `path` and `sources[0].path` from `http://` to `https://`; make `sources[0].name`/`title` descriptive instead of a bare URL
- Add missing `Referee` field to `schema.json` for all leagues (field present in every CSV but absent from all schemas)
- Fix `Date` field `format` from `%d/%m/%y` to `"default"` (ISO 8601); update description to note that pre-2018/19 seasons retain `dd/mm/yy` from source
- Add per-resource descriptions auto-generated from the season code (e.g. "German Bundesliga season 2025/26 match results.")
- Add `season-2526` resource to all `datapackage.json` files (CSV was on disk but not listed)
- Update Bundesliga `README.md`: correct "last 10 seasons" → 33 seasons, remove Travis-CI reference, add license section, document missing-stats and mixed-date-format quirks

🤖 Generated with [Claude Code](https://claude.com/claude-code)