### PR TITLE
Improve metadata: serie-a description, license id, Referee field, README

### DIFF
--- a/datasets/serie-a/README.md
+++ b/datasets/serie-a/README.md
@@ -1,1 +1,11 @@
-This dataset contains data for last 10 seasons of Italian Serie A including current season. The data is updated on weekly basis via Travis-CI. The dataset is sourced from http://www.football-data.co.uk/ website and contains various statistical data such as final and half time result, corners, yellow and red cards etc.
+Italian Serie A match results and statistics, covering all seasons from 1993/94 to present. The data is updated daily via GitHub Actions. The dataset is sourced from https://www.football-data.co.uk/ and includes full-time and half-time results, shots, corners, fouls, yellow and red cards.
+
+## Data notes
+
+- The `Referee` field is present in all files but is always empty — referee data is not available for Serie A.
+- Statistics fields (`HS`, `AS`, `HST`, `AST`, `HF`, `AF`, `HC`, `AC`, `HY`, `AY`, `HR`, `AR`) are empty for seasons 1993/94–2004/05.
+- Half-time fields (`HTHG`, `HTAG`, `HTR`) are empty for seasons 1993/94–1994/95.
+
+## License
+
+Data is made available under the [Open Data Commons Public Domain Dedication and License (PDDL)](https://opendatacommons.org/licenses/pddl/).

--- a/datasets/serie-a/datapackage.json
+++ b/datasets/serie-a/datapackage.json
@@ -1,6 +1,21 @@
 {
   "name": "italian-serie-a",
   "title": "Italian Serie A (football)",
+  "description": "Match results and statistics for the Italian Serie A football league, covering all seasons from 1993/94 to present. Each row is one match and includes full-time and half-time scores, referee, shots, fouls, corners, and cards. The Referee field is present in all files but is always empty as this data is not available for Serie A. Statistics fields (HS–AR) are empty for seasons 1993/94–2004/05. Half-time fields (HTHG, HTAG, HTR) are empty for seasons 1993/94–1994/95.",
+  "licenses": [
+    {
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/",
+      "title": "Open Data Commons Public Domain Dedication and License"
+    }
+  ],
+  "sources": [
+    {
+      "name": "www.football-data.co.uk/",
+      "path": "https://www.football-data.co.uk/",
+      "title": "www.football-data.co.uk/"
+    }
+  ],
   "resources": [
     {
       "name": "season-9900",
@@ -69,6 +84,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -144,7 +165,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1999/00 season."
     },
     {
       "name": "season-9899",
@@ -213,6 +235,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -288,7 +316,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1998/99 season."
     },
     {
       "name": "season-9798",
@@ -357,6 +386,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -432,7 +467,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1997/98 season."
     },
     {
       "name": "season-9697",
@@ -501,6 +537,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -576,7 +618,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1996/97 season."
     },
     {
       "name": "season-9596",
@@ -645,6 +688,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -720,7 +769,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1995/96 season."
     },
     {
       "name": "season-9495",
@@ -789,6 +839,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -864,7 +920,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1994/95 season."
     },
     {
       "name": "season-9394",
@@ -933,6 +990,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1008,7 +1071,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 1993/94 season."
     },
     {
       "name": "season-2526",
@@ -1077,6 +1141,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1152,7 +1222,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2025/26 season."
     },
     {
       "name": "season-2425",
@@ -1221,6 +1292,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1296,7 +1373,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2024/25 season."
     },
     {
       "name": "season-2324",
@@ -1365,6 +1443,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1440,7 +1524,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2023/24 season."
     },
     {
       "name": "season-2223",
@@ -1509,6 +1594,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1584,7 +1675,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2022/23 season."
     },
     {
       "name": "season-2122",
@@ -1653,6 +1745,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1728,7 +1826,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2021/22 season."
     },
     {
       "name": "season-2021",
@@ -1797,6 +1896,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -1872,7 +1977,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2020/21 season."
     },
     {
       "name": "season-1920",
@@ -1941,6 +2047,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2016,7 +2128,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2019/20 season."
     },
     {
       "name": "season-1819",
@@ -2085,6 +2198,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2160,7 +2279,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2018/19 season."
     },
     {
       "name": "season-1718",
@@ -2229,6 +2349,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2304,7 +2430,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2017/18 season."
     },
     {
       "name": "season-1617",
@@ -2373,6 +2500,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2448,7 +2581,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2016/17 season."
     },
     {
       "name": "season-1516",
@@ -2517,6 +2651,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2592,7 +2732,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2015/16 season."
     },
     {
       "name": "season-1415",
@@ -2661,6 +2802,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2736,7 +2883,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2014/15 season."
     },
     {
       "name": "season-1314",
@@ -2805,6 +2953,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -2880,7 +3034,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2013/14 season."
     },
     {
       "name": "season-1213",
@@ -2949,6 +3104,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3024,7 +3185,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2012/13 season."
     },
     {
       "name": "season-1112",
@@ -3093,6 +3255,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3168,7 +3336,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2011/12 season."
     },
     {
       "name": "season-1011",
@@ -3237,6 +3406,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3312,7 +3487,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2010/11 season."
     },
     {
       "name": "season-0910",
@@ -3381,6 +3557,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3456,7 +3638,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2009/10 season."
     },
     {
       "name": "season-0809",
@@ -3525,6 +3708,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3600,7 +3789,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2008/09 season."
     },
     {
       "name": "season-0708",
@@ -3669,6 +3859,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3744,7 +3940,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2007/08 season."
     },
     {
       "name": "season-0607",
@@ -3813,6 +4010,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -3888,7 +4091,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2006/07 season."
     },
     {
       "name": "season-0506",
@@ -3957,6 +4161,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -4032,7 +4242,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2005/06 season."
     },
     {
       "name": "season-0405",
@@ -4101,6 +4312,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -4176,7 +4393,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2004/05 season."
     },
     {
       "name": "season-0304",
@@ -4245,6 +4463,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -4320,7 +4544,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2003/04 season."
     },
     {
       "name": "season-0203",
@@ -4389,6 +4614,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -4464,7 +4695,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2002/03 season."
     },
     {
       "name": "season-0102",
@@ -4533,6 +4765,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -4608,7 +4846,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Match results and statistics for the Italian Serie A 2001/02 season."
     },
     {
       "name": "season-0001",
@@ -4677,6 +4916,12 @@
             "description": "Half Time Result (H=Home Win, D=Draw, A=Away Win)"
           },
           {
+            "name": "Referee",
+            "type": "string",
+            "format": "default",
+            "description": "Match Referee (always empty — referee data is not available for Serie A)"
+          },
+          {
             "name": "HS",
             "type": "integer",
             "format": "default",
@@ -4752,21 +4997,8 @@
         "missingValues": [
           ""
         ]
-      }
-    }
-  ],
-  "licenses": [
-    {
-      "name": "ODC-PDDL",
-      "path": "http://opendatacommons.org/licenses/pddl/",
-      "title": "Open Data Commons Public Domain Dedication and License"
-    }
-  ],
-  "sources": [
-    {
-      "name": "www.football-data.co.uk/",
-      "path": "http://www.football-data.co.uk/",
-      "title": "www.football-data.co.uk/"
+      },
+      "description": "Match results and statistics for the Italian Serie A 2000/01 season."
     }
   ],
   "related": [


### PR DESCRIPTION
- Add package-level `description` covering full season range and data quirks
- Fix `licenses[0].name` from `ODC-PDDL` to `ODC-PDDL-1.0`
- Fix `licenses[0].path` and `sources[0].path` from `http://` to `https://`
- Add missing `Referee` field to all 33 resource schemas (always empty for Serie A)
- Add `description` to all 33 resources
- Rewrite README: correct season count (33 seasons from 1993/94), remove Travis-CI reference, add data notes and license section