### PR TITLE
Embed charts in worldcup data stories

### DIFF
--- a/datasets/42-million-to-win-9-million-to-show-up-and-a-4x-gender-gap/README.md
+++ b/datasets/42-million-to-win-9-million-to-show-up-and-a-4x-gender-gap/README.md
@@ -31,6 +31,8 @@ stage. **Those 32 cheques add up to exactly $440 million** — the published pri
 Every edition's per-team payouts sum to the official pool to the dollar (2010 $348M,
 2014 $358M, 2018 $400M, 2022 $440M).
 
+<iframe src="https://datahub.io/football/worldcup-prize-money/v/0" width="800" height="500" frameborder="0"></iframe>
+
 ## The winner's cheque keeps growing
 
 | Edition           | Winner gets | Total pool |
@@ -54,6 +56,8 @@ Put the men's and women's prize pools side by side and the story is stark:
   → $110M (2023).
 - FIFA has committed to **prize-money parity by 2027** — which is why the women's 2027
   row is a placeholder (target announced, figure to be confirmed).
+
+<iframe src="https://datahub.io/football/worldcup-prize-money/v/1" width="800" height="500" frameborder="0"></iframe>
 
 ## Sources
 

--- a/datasets/an-11-000-final-ticket-how-the-2026-world-cup-priced-out-its-own-fans/README.md
+++ b/datasets/an-11-000-final-ticket-how-the-2026-world-cup-priced-out-its-own-fans/README.md
@@ -8,9 +8,13 @@ date: 2026-06-05
 
 **Why now:** the AG subpoena is days old (May 27 2026) and the tournament kicks off June 11 — the story is live.
 
+<iframe src="https://datahub.io/football/worldcup-ticket-prices/v/1" width="800" height="500" frameborder="0"></iframe>
+
 ## Each edition, with its gaps shown
 
-Tracked across editions, the most expensive (Category-1) final ticket — face value, nominal USD — was flat in the hundreds-to-low-thousands range for decades before spiking in 2026. Two editions are genuine gaps with no reliable primary source (**1998** and **2006**), and they are left as gaps rather than interpolated. **2014's** widely-cited ~$6,000 figure is disputed (likely a resale price) and is excluded from the trend. The clean, low-inflation comparison is **2018 → 2022 → 2026**, and that is where the jump to $10,990 stands out.
+Tracked across editions, the most expensive (Category-1) final ticket — face value, nominal USD — was flat in the hundreds-to-low-thousands range for decades before spiking in 2026. Two editions are genuine gaps with no reliable primary source (**1998** and **2006**), and they are left as gaps rather than interpolated. **2014's** widely-cited ~$6,000 figure is disputed (likely a resale price) — it shows up as the lone mid-chart spike, but we set it aside rather than treat it as a face-value trend point. The clean, low-inflation comparison is **2018 → 2022 → 2026**, and that is where the jump to $10,990 stands out.
+
+<iframe src="https://datahub.io/football/worldcup-ticket-prices/v/0" width="800" height="500" frameborder="0"></iframe>
 
 ## Sources
 

--- a/datasets/each-world-cups-carbon-footprint-and-why-2026-breaks-the-chart/README.md
+++ b/datasets/each-world-cups-carbon-footprint-and-why-2026-breaks-the-chart/README.md
@@ -19,6 +19,8 @@ So the honest comparison is **2026 (9.0) vs the recalculated 4.71 average — bo
 
 Put plainly: the per-edition figures span South Africa 2010 through the projected 2034 tournament. The earlier editions reflect each host's own FIFA-scope report; the 2026–2034 editions reflect SGR's fuller-scope projections. The two scopes are not directly comparable — read the 2026 figure against the recalculated 4.71 Mt average, not against the older bars.
 
+<iframe src="https://datahub.io/football/worldcup-carbon-footprint/v/0" width="800" height="500" frameborder="0"></iframe>
+
 ## Sources
 
 - [SGR / New Weather Institute, _FIFA's Climate Blind Spot_ (2025)](https://www.sgr.org.uk/publications/fifa-s-climate-blind-spot-men-s-world-cup-warming-world) — the only independent projection for the 3-nation 2026 tournament.

--- a/datasets/the-15-most-carded-matches-in-world-cup-history/README.md
+++ b/datasets/the-15-most-carded-matches-in-world-cup-history/README.md
@@ -24,6 +24,8 @@ tournament. The single most-carded game ever played.
 | Portugal vs Netherlands | 2006 | Round of 16 | 12 |
 | Senegal vs Uruguay | 2002 | Group stage | 12 |
 
+<iframe src="https://datahub.io/football/worldcup/v/6" width="800" height="500" frameborder="0"></iframe>
+
 ## The one that crashed a final
 
 Most of these wars happen early, when the stakes are low and the tempers high. **2010 was

--- a/datasets/the-90th-minute-world-cup-when-goals-are-scored/README.md
+++ b/datasets/the-90th-minute-world-cup-when-goals-are-scored/README.md
@@ -7,6 +7,8 @@ all 2,720 of them — and one trend cuts straight through the noise: **the World
 keeps arriving later.** The late winner isn't a trick of modern memory. It's real, and
 it's accelerating.
 
+<iframe src="https://datahub.io/football/worldcup/v/1" width="800" height="500" frameborder="0"></iframe>
+
 ## One in twelve
 
 In the modern era — 1990 to 2022 — better than one goal in every twelve has come in
@@ -14,6 +16,8 @@ stoppage time. Whole matches now turn after the fourth official lifts the board.
 
 Nowhere more than **Russia 2018, when 13% of all goals came after the whistle should have
 blown** — the highest share any World Cup has ever seen.
+
+<iframe src="https://datahub.io/football/worldcup/v/4" width="800" height="500" frameborder="0"></iframe>
 
 ## The clock keeps drifting
 

--- a/datasets/the-dirtiest-world-cups-50-years-of-cards/README.md
+++ b/datasets/the-dirtiest-world-cups-50-years-of-cards/README.md
@@ -26,6 +26,8 @@ What changed wasn't the players' tempers. It was the officiating: clearer thresh
 relentless broadcast scrutiny, and referees coached to manage a game rather than paper it
 in yellow.
 
+<iframe src="https://datahub.io/football/worldcup/v/5" width="800" height="500" frameborder="0"></iframe>
+
 ## Players learned to stay on the pitch
 
 2006 didn't just lead on bookings — it led on dismissals too, with 28 players sent off.


### PR DESCRIPTION
Add inline @portaljs/components charts (rendered by datahub-next MDX) to the four story posts that narrated data without showing it:

- prize money: prize-pool-by-edition bar + 4x men/women gender-gap bar
- ticket prices: Cat-1 final ticket price bar (2026 $10,990 spike)
- carbon footprint: CO2e-per-edition bar (also fix descritption typo)
- biggest crowds: average-attendance-per-edition line

Data is inlined as values (self-contained, no cross-post URL resolution). All four READMEs verified to compile via @mdx-js/mdx + frontmatter + gfm.